### PR TITLE
HP-71: Add error message for creating fund

### DIFF
--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -5,14 +5,15 @@ import { NotificationType } from '../types/notification';
 
 export const useNotification = (): {
   notificationContext: ReactNode;
-  openNotification: (type: NotificationType, content: string) => void
+  openNotification: (type: NotificationType, content: string, duration?: number) => void
 } => {
   const [ messageApi, contextHolder ] = message.useMessage();
 
-  const openNotification = (type: NotificationType, content: string): void => {
+  const openNotification = (type: NotificationType, content: string, duration: number = 3): void => {
     void messageApi.open({
       type,
-      content
+      content,
+      duration
     });
   };
 

--- a/src/mock/api/handler.ts
+++ b/src/mock/api/handler.ts
@@ -5,7 +5,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json([
       {
         id: 1,
-        name: 'Car',
+        name: 'Test_Car_Name',
         plannedAmount: 1000000,
         currentAmount: 649300,
         expenses: [

--- a/src/pages/Funds/Funds.test.tsx
+++ b/src/pages/Funds/Funds.test.tsx
@@ -1,44 +1,50 @@
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
+import { setupServer } from 'msw/node';
 
-import { server } from '../../mock/api/server';
 import { renderWithProviders } from '../../test-utils';
 
 import Funds from './index';
 
+const mockData = [ {
+  id: 1,
+  name: 'cat',
+  plannedAmount: 1000000,
+  currentAmount: 649300,
+  expenses: [
+    {
+      id: 1,
+      paymentAmount: 200600,
+      recipient: 'Mix Mart',
+      description: 'Something else',
+      date: '2022-05-28'
+    },
+    {
+      id: 2,
+      paymentAmount: 150100,
+      recipient: 'FOX',
+      description: 'Something',
+      date: '2022-12-03'
+    }
+  ]
+} ];
+
+const server = setupServer(
+  rest.get('/api/funds', (req, res, ctx) => {
+    return res(ctx.json({ data: mockData }));
+  })
+);
+
 describe('Funds tests', () => {
-  server.use(
-    rest.get('*', (_req, res, ctx) =>
-      res.once(ctx.status(200), ctx.json([ {
-        id: 1,
-        name: 'Car',
-        plannedAmount: 1000000,
-        currentAmount: 649300,
-        expenses: [
-          {
-            id: 1,
-            paymentAmount: 200600,
-            recipient: 'Mix Mart',
-            description: 'Something else',
-            date: '2022-05-28'
-          },
-          {
-            id: 2,
-            paymentAmount: 150100,
-            recipient: 'FOX',
-            description: 'Something',
-            date: '2022-12-03'
-          }
-        ]
-      } ]))
-    )
-  );
+  beforeAll(() => { server.listen(); });
+  afterEach(() => { server.resetHandlers(); });
+  afterAll(() => { server.close(); });
   test('should render fund items', async () => {
     await renderWithProviders(<Funds />);
 
     expect(screen.getByTestId('funds-page-content')).toBeInTheDocument();
     await waitFor(async () => {
-      expect(screen.getByTestId('fund-Car')).toBeInTheDocument();
+      expect(screen.getByTestId(`fund-${mockData[0].name}`)).toBeInTheDocument();
     });
   });
   test('should open and close modal', async () => {
@@ -83,9 +89,9 @@ describe('Funds tests', () => {
 
     expect(screen.getByTestId('funds-page-content')).toBeInTheDocument();
     await waitFor(async () => {
-      expect(screen.getByTestId('fund-Car')).toBeInTheDocument();
-      expect(screen.getByTestId('fund-Car-remove-fund')).toBeInTheDocument();
-      fireEvent.click(screen.getByTestId('fund-Car-remove-fund'));
+      expect(screen.getByTestId(`fund-${mockData[0].name}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`fund-${mockData[0].name}-remove-fund`)).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId(`fund-${mockData[0].name}-remove-fund`));
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error

--- a/src/pages/Funds/index.tsx
+++ b/src/pages/Funds/index.tsx
@@ -3,13 +3,15 @@ import { useCallback } from 'react';
 import {
   AddIcon,
   Empty,
-  TooltipIconButton,
   Page,
-  Row
+  Row,
+  TooltipIconButton
 } from '../../components';
-import { useModal, useNotification } from '../../hooks';
 import {
-  useCreateFundMutation,
+  useModal,
+  useNotification
+} from '../../hooks';
+import {
   useDeleteFundMutation,
   useFetchFundsQuery
 } from '../../services/funds';
@@ -23,24 +25,15 @@ const Funds = (): JSX.Element => {
   const { isOpenModal, hideModal, openModal } = useModal();
   const { data: funds = [], isLoading } = useFetchFundsQuery(undefined, { refetchOnMountOrArgChange: true });
   const [ deleteFund ] = useDeleteFundMutation();
-  const [ createFund ] = useCreateFundMutation();
   const { notificationContext, openNotification } = useNotification();
   const isEmptyComponent: boolean = !funds.length && !isLoading;
-
-  const handleCreateNewFund = useCallback((fund: Fund) => {
-    void createFund(fund)
-      .then(() => {
-        openNotification(NotificationType.SUCCESS, `Fund "${fund.name}" was created successfully!`);
-        hideModal();
-      });
-  }, [ createFund, hideModal, openNotification ]);
 
   const handleDeleteFund = useCallback((fund: Fund) => {
     void deleteFund(fund.id ?? 0)
       .then(() => {
         openNotification(NotificationType.SUCCESS, `Fund "${fund.name}" was deleted successfully!`);
       });
-  }, [ createFund, hideModal, openNotification ]);
+  }, [ deleteFund, openNotification ]);
 
   return (
     <Page
@@ -69,7 +62,7 @@ const Funds = (): JSX.Element => {
       <FundModal
         isOpen={isOpenModal}
         onCancel={hideModal}
-        onSave={handleCreateNewFund}
+        openNotification={openNotification}
       />
     </Page>
   );

--- a/src/utils/form.test.ts
+++ b/src/utils/form.test.ts
@@ -1,0 +1,24 @@
+
+import {
+  errorFundAmountMessage,
+  generateError
+} from './form';
+import { convertToCurrency } from './fund';
+
+describe('Form util tests', () => {
+  test('should create error', () => {
+    const error = {
+      name: 'name',
+      errors: [ 'Error name' ]
+    };
+
+    expect(generateError('name', [ 'Error name' ])).toEqual(error);
+  });
+
+  describe('Fund Amount Error', () => {
+    test('should create error message', () => {
+      const message = `The amount must be less than or equal to ${convertToCurrency(1000)} (available bank money)`;
+      expect(errorFundAmountMessage(1000)).toEqual(message);
+    });
+  });
+});

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -1,0 +1,15 @@
+import { convertToCurrency } from './fund';
+
+interface IFormError {
+  name: string;
+  errors: string[]
+}
+
+export const generateError = (fieldName: string, errors: string[]): IFormError => ({
+  name: fieldName,
+  errors
+});
+
+export const errorFundAmountMessage = (bankAmount: number): string => {
+  return `The amount must be less than or equal to ${convertToCurrency(bankAmount)} (available bank money)`;
+};


### PR DESCRIPTION
# Summary
Restrictions for Creating Fund

# Screenshots
<img width="1321" alt="image" src="https://github.com/Nuta88/react-happy-pig/assets/19836178/220d3005-fa36-4f86-a674-d747fa3fc652">

# Testing
> **GIVEN:** Fund page and bunk amount 190$
> **WHEN:** User opens Funds page
> **AND:** User clicks on "Add Fund" button
> **THEN:** User sees "**Create new fund"** modal with fields:

| \# | **Field** |
| --- | --- |
| 1 | Name |
| 2 | Amount |

> **AND:** User fills in the fields correctly:

| **Field** | **Value** |
| --- | --- |
| Name | New fund |
| Amount | 265 |

> **AND:** User see error for amount field: The amount must be less than or equal to 190 (available bank money)