### PR TITLE
HP-78: Fix Expense button and error for saving and updating

### DIFF
--- a/src/pages/Bank/index.tsx
+++ b/src/pages/Bank/index.tsx
@@ -22,7 +22,7 @@ const Bank = (): JSX.Element => {
     hideModal,
     openModal
   } = useModal<Income>();
-  const { data: { amount, incomes = [] } = {}, isLoading } = useFetchBankQuery({});
+  const { data: { amount, incomes = [] } = {}, isLoading } = useFetchBankQuery(undefined, { refetchOnMountOrArgChange: true });
   const [ createIncome ] = useCreateIncomeMutation();
   const [ deleteIncome ] = useDeleteIncomeMutation();
   const columns: ColumnsType<Income> = generateColumns(openModal, deleteIncome);

--- a/src/pages/FundDetail/components/ExpenseModal/index.tsx
+++ b/src/pages/FundDetail/components/ExpenseModal/index.tsx
@@ -48,10 +48,19 @@ const ExpenseModal: FC<IExpenseModalProps> = ({ isOpen, expense, availableAmount
   const onFinish = (values: IFormValues): void => {
     const penniesAmount = convertToPennies(values.paymentAmount);
 
-    if (penniesAmount > availableAmount) {
+    if (!expense && penniesAmount > availableAmount) {
       setAmountFormError(availableAmount);
       return;
     }
+
+    if (expense) {
+      const availableExpense = availableAmount + expense?.paymentAmount;
+      if (penniesAmount > availableExpense) {
+        setAmountFormError(availableExpense);
+        return;
+      }
+    }
+
     form.resetFields();
     onSave(convertFormValuesToExpense(expense, values));
   };

--- a/src/pages/FundDetail/index.tsx
+++ b/src/pages/FundDetail/index.tsx
@@ -59,7 +59,7 @@ const FundDetail = (): JSX.Element => {
           icon={<AddIcon />}
           data-testid="fund-open-create-modal"
           onClick={handleOpenCreateModal}
-          disabled={totalAmountOfExpenses === fund?.currentAmount}
+          disabled={fund?.currentAmount === 0}
         />
       }
     >
@@ -78,7 +78,7 @@ const FundDetail = (): JSX.Element => {
           expense={selectedExpense}
           onSave={onUpdateOrCreateExpense}
           onCancel={hideModal}
-          availableAmount={(fund?.currentAmount ?? 0) - totalAmountOfExpenses}
+          availableAmount={(fund?.currentAmount ?? 0)}
         />
       )}
     </Page>


### PR DESCRIPTION
# Summary
_Expense button is disabled_

# Screenshots
<img width="915" alt="image" src="https://github.com/Nuta88/react-happy-pig/assets/19836178/bf7d8273-3fee-4295-a010-21bd8663af5a">

# Details
1. Fix disabled expense button
2. Fix validation for create and update expense