### PR TITLE
Feature/hp 117 UI ux improvements

### DIFF
--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -6,6 +6,7 @@ const SpinStyled = styled(Spin)`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+    z-index: 100;
 `;
 
 export const Loading = (props: JSX.IntrinsicAttributes & SpinProps): JSX.Element => (

--- a/src/pages/FundDetail/components/ExpenseModal/index.tsx
+++ b/src/pages/FundDetail/components/ExpenseModal/index.tsx
@@ -7,6 +7,7 @@ import {
 
 import {
   BasicModal,
+  Button,
   Input
 } from '../../../../components';
 import { layout } from '../../../../constants/form';
@@ -79,9 +80,12 @@ const ExpenseModal: FC<IExpenseModalProps> = ({ isOpen, expense, availableAmount
     <BasicModal
       title={title}
       isOpen={isOpen}
-      okText={isEdit ? 'Edit' : 'Add'}
-      onOk={form.submit}
       onCancel={onCloseModal}
+      footer={[
+        <Button key="submit" type="primary" onClick={form.submit}>
+          {isEdit ? 'Edit' : 'Add'}
+        </Button>
+      ]}
     >
       <>
         <Form

--- a/src/pages/FundDetail/components/FundInfo/components/FundInfoActions/index.tsx
+++ b/src/pages/FundDetail/components/FundInfo/components/FundInfoActions/index.tsx
@@ -1,0 +1,40 @@
+import { FC } from 'react';
+
+import {
+  Button,
+  PrimaryButton,
+  Space
+} from '../../../../../../components';
+
+interface InfoActionsProps {
+  isEdit: boolean;
+  isChanged: boolean;
+  onEdit: () => void;
+  onHideEdit: () => void;
+  onSubmit: () => void
+}
+
+export const FundInfoActions: FC<InfoActionsProps> = ({
+  isEdit, onHideEdit, isChanged, onEdit, onSubmit
+}): JSX.Element => (
+  <Space>
+    {isEdit
+      ? (
+        <>
+          <Button onClick={onHideEdit}>Cancel</Button>
+          <PrimaryButton
+            onClick={onSubmit}
+            disabled={!isChanged}
+          >
+            Save
+          </PrimaryButton>
+        </>
+        )
+      : (
+        <PrimaryButton onClick={onEdit}>
+          Edit
+        </PrimaryButton>
+        )
+    }
+  </Space>
+);

--- a/src/pages/FundDetail/components/FundInfo/index.tsx
+++ b/src/pages/FundDetail/components/FundInfo/index.tsx
@@ -1,13 +1,13 @@
 import { List } from 'antd';
 import {
   FC,
-  useState
+  useState,
+  useEffect
 } from 'react';
 import styled from 'styled-components';
 
 import {
   AddIcon,
-  Button,
   DashedButton,
   Drawer,
   Empty,
@@ -16,10 +16,8 @@ import {
   Link,
   LinkIcon,
   MinusCircleIcon,
-  PrimaryButton,
   Radio,
   SecondaryText,
-  Space,
   Text
 } from '../../../../components';
 import { FundPriority } from '../../../../constants/fund';
@@ -27,7 +25,9 @@ import { Fund } from '../../../../types';
 import { IFundInfo } from '../../../../types/fund';
 import { disablePreviousDate } from '../../../../utils/date';
 import { getAmount } from '../../../../utils/fund';
+import { isObjectEmpty } from '../../../../utils/object';
 
+import { FundInfoActions } from './components/FundInfoActions';
 import {
   convertFormValuesToFund,
   createInitialValues
@@ -71,6 +71,16 @@ export const FundInfo: FC<InfoProps> = ({ open, fund, onClose, onSave }): JSX.El
   const [ form ] = Form.useForm();
   const priorityOptions = Object.entries(FundPriority);
   const initialValues = createInitialValues(fund);
+  const [ isChanged, setIsChanged ] = useState(false);
+  const watchedValues = Form.useWatch([], form); // watch all form values
+
+  useEffect(() => {
+    const currentValues = form.getFieldsValue(true);
+
+    if (!isObjectEmpty(currentValues)) {
+      setIsChanged(JSON.stringify(currentValues) !== JSON.stringify(initialValues));
+    }
+  }, [ watchedValues ]);
 
   const handleEdit = (): void => {
     form.setFieldsValue(initialValues);
@@ -87,6 +97,7 @@ export const FundInfo: FC<InfoProps> = ({ open, fund, onClose, onSave }): JSX.El
     onClose();
     form.resetFields();
   };
+
   const handleUpdateFund = (values: IFundInfo): void => {
     onSave(convertFormValuesToFund(values));
     handleHideEdit();
@@ -98,19 +109,13 @@ export const FundInfo: FC<InfoProps> = ({ open, fund, onClose, onSave }): JSX.El
       placement="right"
       width={500}
       extra={
-        <Space>
-          {isEdit && (
-            <>
-              <Button onClick={handleHideEdit}>Cancel</Button>
-              <PrimaryButton onClick={form.submit}>
-                Save
-              </PrimaryButton>
-            </>
-          )}
-          <PrimaryButton onClick={handleEdit}>
-            Edit
-          </PrimaryButton>
-        </Space>
+        <FundInfoActions
+          isEdit={isEdit}
+          isChanged={isChanged}
+          onHideEdit={handleHideEdit}
+          onEdit={handleEdit}
+          onSubmit={form.submit}
+        />
       }
       onClose={handleClose}
       open={open}

--- a/src/utils/fund.test.ts
+++ b/src/utils/fund.test.ts
@@ -7,6 +7,16 @@ import {
   upsertExpense
 } from './fund';
 
+const expenses = [
+  {
+    id: 1,
+    paymentAmount: 150100,
+    recipient: 'Test recipient',
+    description: 'Test',
+    date: '2022-12-03'
+  }
+];
+
 describe('FundDetail util tests', () => {
   describe('Convert to currency tests', () => {
     const pennies = 1000;
@@ -57,8 +67,8 @@ describe('FundDetail util tests', () => {
   });
   describe('Percentage tests', () => {
     test('should return fund percentage', () => {
-      const data = { currentAmount: 10, plannedAmount: 1000 };
-      const result = 99;
+      const data = { expenses, plannedAmount: 1000 };
+      const result = 15010;
 
       expect(getPercentage(data)).toEqual(result);
     });
@@ -70,15 +80,6 @@ describe('FundDetail util tests', () => {
     });
   });
   describe('Upsert FundDetail Expense tests', () => {
-    const expenses = [
-      {
-        id: 1,
-        paymentAmount: 150100,
-        recipient: 'Test recipient',
-        description: 'Test',
-        date: '2022-12-03'
-      }
-    ];
     test('should add new expense to list', () => {
       const expense = {
         id: 2,

--- a/src/utils/fund.ts
+++ b/src/utils/fund.ts
@@ -1,7 +1,7 @@
 import { Expense } from '../types';
 
 interface IPercentage {
-  currentAmount?: number | null;
+  expenses?: Expense[];
   plannedAmount?: number
 }
 
@@ -9,8 +9,10 @@ export const convertToCurrency = (amount: number = 0): number => (amount / 100);
 
 export const convertToPennies = (amount: number): number => (amount * 100);
 
-export const getPercentage = ({ currentAmount = 1, plannedAmount = 1 }: IPercentage): number => {
-  return Math.floor(100 - (((currentAmount ?? 1) / plannedAmount) * 100));
+export const getPercentage = ({ expenses = [], plannedAmount = 0 }: IPercentage): number => {
+  if (plannedAmount === 0) return 0;
+
+  return Math.floor((countPaymentAmounts(expenses) / plannedAmount) * 100);
 };
 
 export const formatter = new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
# Summary
_Feature/hp 117 UI ux improvements_

# Details

1. Delete button "Cancel" from the “Add expense” modal window
2. Fix spinner on the landing page (it's located under the content but should be located above ones)
3. Add spinner to moving Expenses
4. Tab "Funds" -> click on the button "Info" -> click on the button "Edit" -> the button "Edit" should be removed
5. Change the progress bar logic for the Fund card to the following formula:
fund_progress_bar_indicator [%] = (sum(expenses)/plannedAmount)*100, when plannedAmount > 0
fund_progress_bar_indicator [%] = 0% when plannedAmount = 0